### PR TITLE
feat(contracts): add approved relayer

### DIFF
--- a/contracts/src/SP1Blobstream.sol
+++ b/contracts/src/SP1Blobstream.sol
@@ -119,7 +119,7 @@ contract SP1Blobstream is ISP1Blobstream, IDAOracle, TimelockedUpgradeable {
         blobstreamProgramVkey = _programVkey;
     }
 
-    /// @notice Approve a relayer.
+    /// @notice Set a relayer's approval status.
     function setRelayerApproval(address _relayer, bool _approved) external onlyGuardian {
         approvedRelayers[_relayer] = _approved;
     }

--- a/contracts/src/SP1Blobstream.sol
+++ b/contracts/src/SP1Blobstream.sol
@@ -73,7 +73,7 @@ contract SP1Blobstream is ISP1Blobstream, IDAOracle, TimelockedUpgradeable {
 
     /// @notice If the relayer check is enabled, only approved relayers can call the function.
     modifier onlyApprovedRelayer() {
-        if (!checkRelayer || approvedRelayers[msg.sender]) {
+        if (checkRelayer && !approvedRelayers[msg.sender]) {
             revert RelayerNotApproved();
         }
         _;

--- a/contracts/src/SP1Blobstream.sol
+++ b/contracts/src/SP1Blobstream.sol
@@ -120,8 +120,8 @@ contract SP1Blobstream is ISP1Blobstream, IDAOracle, TimelockedUpgradeable {
     }
 
     /// @notice Approve a relayer.
-    function approveRelayer(address _relayer) external onlyGuardian {
-        approvedRelayers[_relayer] = true;
+    function setRelayerApproval(address _relayer, bool _approved) external onlyGuardian {
+        approvedRelayers[_relayer] = _approved;
     }
 
     /// @notice Set the relayer check.

--- a/contracts/src/SP1Blobstream.sol
+++ b/contracts/src/SP1Blobstream.sol
@@ -48,6 +48,12 @@ contract SP1Blobstream is ISP1Blobstream, IDAOracle, TimelockedUpgradeable {
     /// @notice The deployed SP1 verifier contract.
     ISP1Verifier public verifier;
 
+    /// @notice Approved relayers for the contract.
+    mapping(address => bool) public approvedRelayers;
+
+    /// @notice Check the relayer is approved.
+    bool public checkRelayer = false;
+
     struct InitParameters {
         address guardian;
         uint64 height;
@@ -63,6 +69,14 @@ contract SP1Blobstream is ISP1Blobstream, IDAOracle, TimelockedUpgradeable {
         uint64 trustedBlock;
         uint64 targetBlock;
         uint256 validatorBitmap;
+    }
+
+    /// @notice If the relayer check is enabled, only approved relayers can call the function.
+    modifier onlyApprovedRelayer() {
+        if (!checkRelayer || approvedRelayers[msg.sender]) {
+            revert RelayerNotApproved();
+        }
+        _;
     }
 
     function VERSION() external pure override returns (string memory) {
@@ -105,11 +119,24 @@ contract SP1Blobstream is ISP1Blobstream, IDAOracle, TimelockedUpgradeable {
         blobstreamProgramVkey = _programVkey;
     }
 
+    /// @notice Approve a relayer.
+    function approveRelayer(address _relayer) external onlyGuardian {
+        approvedRelayers[_relayer] = true;
+    }
+
+    /// @notice Set the relayer check.
+    function setRelayerCheck(bool _checkRelayer) external onlyGuardian {
+        checkRelayer = _checkRelayer;
+    }
+
     /// @notice Commits the new header at targetBlock and the data commitment for the block range
     /// [latestBlock, targetBlock).
     /// @param proof The proof bytes for the SP1 proof.
     /// @param publicValues The public commitments from the SP1 proof.
-    function commitHeaderRange(bytes calldata proof, bytes calldata publicValues) external {
+    function commitHeaderRange(bytes calldata proof, bytes calldata publicValues)
+        external
+        onlyApprovedRelayer
+    {
         if (frozen) {
             revert ContractFrozen();
         }

--- a/contracts/src/interfaces/ISP1Blobstream.sol
+++ b/contracts/src/interfaces/ISP1Blobstream.sol
@@ -60,4 +60,7 @@ interface ISP1Blobstream {
 
     /// @notice Data commitment for specified block range does not exist.
     error DataCommitmentNotFound();
+
+    /// @notice Relayer not approved.
+    error RelayerNotApproved();
 }

--- a/contracts/test/SP1Blobstream.t.sol
+++ b/contracts/test/SP1Blobstream.t.sol
@@ -19,7 +19,7 @@ contract SP1BlobstreamTest is Test {
         require(keccak256(encodedInput) == keccak256(packedEncodedInput), "packed matches");
     }
 
-    function testGetEncodePackedNextHeader() public view {
+    function testGetEncodePackedNextHeader() public pure {
         // http://64.227.18.169:26657/block?height=10000
         uint64 height = 10000;
         bytes32 header = hex"A0123D5E4B8B8888A61F931EE2252D83568B97C223E0ECA9795B29B8BD8CBA2D";
@@ -27,7 +27,7 @@ contract SP1BlobstreamTest is Test {
         console.logBytes(encodedInput);
     }
 
-    function testGetEncodePackedHeaderRange() public view {
+    function testGetEncodePackedHeaderRange() public pure {
         // http://64.227.18.169:26657/block?height=10000
         uint64 height = 10000;
         bytes32 header = hex"A0123D5E4B8B8888A61F931EE2252D83568B97C223E0ECA9795B29B8BD8CBA2D";


### PR DESCRIPTION
Add approved relaying to the contract. This feature needs to be turned on, and restricts the accounts that can relay to `commitHeaderRange`.