### PR TITLE
feat: audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,8 @@ the `SP1Blobstream` contract.
     TENDERMINT_RPC_URL=https://rpc.celestia-mocha.com/ CHAIN_ID=11155111 RPC_URL=https://ethereum-sepolia.publicnode.com/
     CONTRACT_ADDRESS=<SP1_BLOBSTREAM_ADDRESS> cargo run --bin operator --release
     ```
+
+## Known Limitations
+
+**Warning:** The implementation of SP1 Blobstream assumes that the number of validators is less than 256. This limitation is due to the use of a 256-bit bitmap to represent validator signatures. If the number of validators exceeds 256, the `validatorBitmap` functionality may not work as intended, potentially leading to incorrect or incomplete validator equivocation check.
+

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ the `SP1Blobstream` contract.
 
 ## Known Limitations
 
-**Warning:** The implementation of SP1 Blobstream assumes that the number of validators is less than 256. This limitation is due to the use of a 256-bit bitmap to represent whether a validator has signed off on a header. If the number of validators exceeds 256, the `validatorBitmap` functionality may not work as intended, potentially leading to an incomplete
-validator equivocation.
+**Warning:** The implementation of SP1 Blobstream assumes that the number of validators is less than 
+256. This limitation is due to the use of a 256-bit bitmap to represent whether a validator has 
+signed off on a header. If the number of validators exceeds 256, the `validatorBitmap` functionality
+may not work as intended, potentially leading to an incomplete validator equivocation. 
+
+On Celestia, the number of validators is currently 100, and there are no plans to increase this number
+significantly. If it was to be increased, the signature aggregation logic in the consensus protocol
+would likely change as well, which would also necessitate a change in the SP1 Blobstream implementation.
 

--- a/README.md
+++ b/README.md
@@ -90,5 +90,6 @@ the `SP1Blobstream` contract.
 
 ## Known Limitations
 
-**Warning:** The implementation of SP1 Blobstream assumes that the number of validators is less than 256. This limitation is due to the use of a 256-bit bitmap to represent validator signatures. If the number of validators exceeds 256, the `validatorBitmap` functionality may not work as intended, potentially leading to incorrect or incomplete validator equivocation check.
+**Warning:** The implementation of SP1 Blobstream assumes that the number of validators is less than 256. This limitation is due to the use of a 256-bit bitmap to represent whether a validator has signed off on a header. If the number of validators exceeds 256, the `validatorBitmap` functionality may not work as intended, potentially leading to an incomplete
+validator equivocation.
 

--- a/contracts/src/interfaces/ISP1Blobstream.sol
+++ b/contracts/src/interfaces/ISP1Blobstream.sol
@@ -11,9 +11,6 @@ interface ISP1Blobstream {
     /// @notice Trusted header not found.
     error TrustedHeaderNotFound();
 
-    /// @notice Latest header not found.
-    error LatestHeaderNotFound();
-
     /// @notice Target block for proof must be greater than latest block and less than the
     /// latest block plus the maximum number of skipped blocks.
     error TargetBlockNotInRange();
@@ -44,22 +41,6 @@ interface ISP1Blobstream {
     event ValidatorBitmapEquivocation(
         uint64 trustedBlock, uint64 targetBlock, uint256 validatorBitmap
     );
-
-    /// @notice Emits event with the inputs of a next header request.
-    /// @param trustedBlock The trusted block for the next header request.
-    /// @param trustedHeader The header hash of the trusted block.
-    event NextHeaderRequested(uint64 indexed trustedBlock, bytes32 indexed trustedHeader);
-
-    /// @notice Emits event with the inputs of a header range request.
-    /// @param trustedBlock The trusted block for the header range request.
-    /// @param trustedHeader The header hash of the trusted block.
-    /// @param targetBlock The target block of the header range request.
-    event HeaderRangeRequested(
-        uint64 indexed trustedBlock, bytes32 indexed trustedHeader, uint64 indexed targetBlock
-    );
-
-    /// @notice Data commitment for specified block range does not exist.
-    error DataCommitmentNotFound();
 
     /// @notice Relayer not approved.
     error RelayerNotApproved();

--- a/contracts/test/SP1Blobstream.t.sol
+++ b/contracts/test/SP1Blobstream.t.sol
@@ -19,7 +19,7 @@ contract SP1BlobstreamTest is Test {
         require(keccak256(encodedInput) == keccak256(packedEncodedInput), "packed matches");
     }
 
-    function testGetEncodePackedNextHeader() public pure {
+    function testGetEncodePackedNextHeader() public view {
         // http://64.227.18.169:26657/block?height=10000
         uint64 height = 10000;
         bytes32 header = hex"A0123D5E4B8B8888A61F931EE2252D83568B97C223E0ECA9795B29B8BD8CBA2D";
@@ -27,7 +27,7 @@ contract SP1BlobstreamTest is Test {
         console.logBytes(encodedInput);
     }
 
-    function testGetEncodePackedHeaderRange() public pure {
+    function testGetEncodePackedHeaderRange() public view {
         // http://64.227.18.169:26657/block?height=10000
         uint64 height = 10000;
         bytes32 header = hex"A0123D5E4B8B8888A61F931EE2252D83568B97C223E0ECA9795B29B8BD8CBA2D";

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -15,8 +15,6 @@ pub type ProofOutputs = sol! {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProofInputs {
-    pub trusted_block_height: u64,
-    pub target_block_height: u64,
     pub trusted_light_block: LightBlock,
     pub target_light_block: LightBlock,
     /// Exclusive of trusted_light_block and target_light_block's headers

--- a/program/src/main.rs
+++ b/program/src/main.rs
@@ -69,7 +69,7 @@ fn get_validator_bitmap_commitment(
     trusted_light_block: &LightBlock,
     target_light_block: &LightBlock,
 ) -> U256 {
-    // If a validtor has signed off on both headers, add them to the intersection set.
+    // If a validator has signed off on both headers, add them to the intersection set.
     let mut validator_commit_intersection = HashSet::new();
     for i in 0..trusted_light_block.signed_header.commit.signatures.len() {
         for j in 0..target_light_block.signed_header.commit.signatures.len() {
@@ -108,8 +108,6 @@ fn main() {
     let proof_inputs = serde_cbor::from_slice(&proof_inputs_vec).unwrap();
 
     let ProofInputs {
-        trusted_block_height,
-        target_block_height,
         trusted_light_block,
         target_light_block,
         headers,
@@ -152,8 +150,8 @@ fn main() {
         trusted_header_hash,
         target_header_hash,
         data_commitment,
-        trusted_block_height,
-        target_block_height,
+        trusted_light_block.signed_header.header.height.value(),
+        target_light_block.signed_header.header.height.value(),
         validator_bitmap_u256,
     ));
     sp1_zkvm::io::commit_slice(&proof_outputs);

--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,7 @@ services:
     rootDir: script
     buildCommand: rm -rf build.rs && cargo build --bin operator --release
     startCommand: cargo run --bin operator --release
-    autoDeploy: true
+    autoDeploy: false
     envVars:
       - key: TENDERMINT_RPC_URL
         value: https://rpc.celestia-mocha.com/

--- a/script/src/lib.rs
+++ b/script/src/lib.rs
@@ -51,8 +51,6 @@ impl TendermintProver {
         }
 
         ProofInputs {
-            trusted_block_height,
-            target_block_height,
             trusted_light_block: light_blocks[0].clone(),
             target_light_block: light_blocks[light_blocks.len() - 1].clone(),
             headers,


### PR DESCRIPTION
- Remove unused events from `ISP1Blobsream`.
- Add warning about maximum number of validators with SP1 Blobstream.
- Rather than separately passing in the `trusted_block_height` and `target_block_height`, use the heights from the LightBlock's.