### PR TITLE
feat(contracts): bump max data commitment

### DIFF
--- a/contracts/script/Upgrade.s.sol
+++ b/contracts/script/Upgrade.s.sol
@@ -26,22 +26,22 @@ contract UpgradeScript is BaseScript {
             string.concat("CONTRACT_ADDRESS_", vm.toString(block.chainid));
 
         // Deploy new SP1Blobstream.
-        SP1Blobstream newSP1Blobstream = new SP1Blobstream();
+        SP1Blobstream newSP1Blobstream = new SP1Blobstream{salt: bytes32(0)}();
 
         // Upgrade the existing Blobstream.
         SP1Blobstream existingBlobstream = SP1Blobstream(vm.envAddress(contractAddressKey));
 
-        existingBlobstream.upgradeTo(address(newSP1Blobstream));
+        // existingBlobstream.upgradeTo(address(newSP1Blobstream));
 
-        existingBlobstream.updateVerifier(0x3B6041173B80E77f038f3F2C0f9744f04837185e);
+        // existingBlobstream.updateVerifier(0x3B6041173B80E77f038f3F2C0f9744f04837185e);
 
-        existingBlobstream.updateProgramVkey(vm.envBytes32("SP1_BLOBSTREAM_PROGRAM_VKEY"));
+        // existingBlobstream.updateProgramVkey(vm.envBytes32("SP1_BLOBSTREAM_PROGRAM_VKEY"));
 
-        // Enable relayer check.
-        existingBlobstream.setCheckRelayer(true);
+        // // Enable relayer check.
+        // existingBlobstream.setCheckRelayer(true);
 
-        existingBlobstream.setRelayerApproval(0x44eB418A966ff47f5AF6f48AEa6Afde0bf193a8d, true);
-        // P-OPS relayer on Mocha chains.
-        existingBlobstream.setRelayerApproval(0xEdaCeBA3c0F0beb91771A4193784051a72f44983, true);
+        // existingBlobstream.setRelayerApproval(0x44eB418A966ff47f5AF6f48AEa6Afde0bf193a8d, true);
+        // // P-OPS relayer on Mocha chains.
+        // existingBlobstream.setRelayerApproval(0xEdaCeBA3c0F0beb91771A4193784051a72f44983, true);
     }
 }

--- a/contracts/src/SP1Blobstream.sol
+++ b/contracts/src/SP1Blobstream.sol
@@ -20,7 +20,7 @@ contract SP1Blobstream is ISP1Blobstream, IDAOracle, TimelockedUpgradeable {
 
     /// @notice The maximum number of blocks that can be skipped in a single request.
     /// @dev Reflects the maximum data commitment size you can request from a Celestia node.
-    uint64 public constant DATA_COMMITMENT_MAX = 1000;
+    uint64 public constant DATA_COMMITMENT_MAX = 10000;
 
     /// @notice Nonce for proof events. Must be incremented sequentially.
     uint256 public state_proofNonce;

--- a/render.yaml
+++ b/render.yaml
@@ -16,6 +16,8 @@ services:
         value: 17000
       - key: CONTRACT_ADDRESS
         value: 0x315A044cb95e4d44bBf6253585FbEbcdB6fb41ef
+      - key: BLOCK_UPDATE_INTERVAL
+        value: 300
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER
@@ -45,6 +47,8 @@ services:
         value: 11155111
       - key: CONTRACT_ADDRESS
         value: 0xF0c6429ebAB2e7DC6e05DaFB61128bE21f13cb1e
+      - key: BLOCK_UPDATE_INTERVAL
+        value: 300
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER
@@ -74,6 +78,8 @@ services:
         value: 421614
       - key: CONTRACT_ADDRESS
         value: 0xc3e209eb245Fd59c8586777b499d6A665DF3ABD2
+      - key: BLOCK_UPDATE_INTERVAL
+        value: 300
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER
@@ -103,6 +109,8 @@ services:
         value: 84532
       - key: CONTRACT_ADDRESS
         value: 0xc3e209eb245Fd59c8586777b499d6A665DF3ABD2
+      - key: BLOCK_UPDATE_INTERVAL
+        value: 300
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER
@@ -130,6 +138,8 @@ services:
         value: 1
       - key: CONTRACT_ADDRESS
         value: 0x7Cf3876F681Dbb6EdA8f6FfC45D66B996Df08fAe
+      - key: BLOCK_UPDATE_INTERVAL
+        value: 900
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER
@@ -157,6 +167,8 @@ services:
         value: 8453
       - key: CONTRACT_ADDRESS
         value: 0xA83ca7775Bc2889825BcDeDfFa5b758cf69e8794
+      - key: BLOCK_UPDATE_INTERVAL
+        value: 300
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER
@@ -184,6 +196,8 @@ services:
         value: 42161
       - key: CONTRACT_ADDRESS
         value: 0xA83ca7775Bc2889825BcDeDfFa5b758cf69e8794
+      - key: BLOCK_UPDATE_INTERVAL
+        value: 300
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER


### PR DESCRIPTION
## Overview
- Bump the `DATA_COMMITMENT_MAX` to 10000
- Add the `BLOCK_UPDATE_INTERVAL` to the `render.yaml` for all of the chains.

## Misc
Command to deploy the upgrade on the testnets:

```shell
forge script ./script/Upgrade.s.sol --verify --verifier etherscan --multi --ledger --mnemonic-indexes 0 --sender 0xbab2c2af5b91695e65955da60d63ad1b2ae81126 --broadcast
```