### PR TITLE
feat: ginger block update interval

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -139,7 +139,7 @@ services:
       - key: CONTRACT_ADDRESS
         value: 0x7Cf3876F681Dbb6EdA8f6FfC45D66B996Df08fAe
       - key: BLOCK_UPDATE_INTERVAL
-        value: 1800
+        value: 900
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER
@@ -168,7 +168,7 @@ services:
       - key: CONTRACT_ADDRESS
         value: 0xA83ca7775Bc2889825BcDeDfFa5b758cf69e8794
       - key: BLOCK_UPDATE_INTERVAL
-        value: 600
+        value: 300
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER
@@ -197,7 +197,7 @@ services:
       - key: CONTRACT_ADDRESS
         value: 0xA83ca7775Bc2889825BcDeDfFa5b758cf69e8794
       - key: BLOCK_UPDATE_INTERVAL
-        value: 600
+        value: 300
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER

--- a/render.yaml
+++ b/render.yaml
@@ -17,7 +17,7 @@ services:
       - key: CONTRACT_ADDRESS
         value: 0x315A044cb95e4d44bBf6253585FbEbcdB6fb41ef
       - key: BLOCK_UPDATE_INTERVAL
-        value: 300
+        value: 600
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER
@@ -48,7 +48,7 @@ services:
       - key: CONTRACT_ADDRESS
         value: 0xF0c6429ebAB2e7DC6e05DaFB61128bE21f13cb1e
       - key: BLOCK_UPDATE_INTERVAL
-        value: 300
+        value: 600
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER
@@ -79,7 +79,7 @@ services:
       - key: CONTRACT_ADDRESS
         value: 0xc3e209eb245Fd59c8586777b499d6A665DF3ABD2
       - key: BLOCK_UPDATE_INTERVAL
-        value: 300
+        value: 600
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER
@@ -110,7 +110,7 @@ services:
       - key: CONTRACT_ADDRESS
         value: 0xc3e209eb245Fd59c8586777b499d6A665DF3ABD2
       - key: BLOCK_UPDATE_INTERVAL
-        value: 300
+        value: 600
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER
@@ -139,7 +139,7 @@ services:
       - key: CONTRACT_ADDRESS
         value: 0x7Cf3876F681Dbb6EdA8f6FfC45D66B996Df08fAe
       - key: BLOCK_UPDATE_INTERVAL
-        value: 900
+        value: 1800
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER
@@ -168,7 +168,7 @@ services:
       - key: CONTRACT_ADDRESS
         value: 0xA83ca7775Bc2889825BcDeDfFa5b758cf69e8794
       - key: BLOCK_UPDATE_INTERVAL
-        value: 300
+        value: 600
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER
@@ -197,7 +197,7 @@ services:
       - key: CONTRACT_ADDRESS
         value: 0xA83ca7775Bc2889825BcDeDfFa5b758cf69e8794
       - key: BLOCK_UPDATE_INTERVAL
-        value: 300
+        value: 600
       - key: TENDERMINT_RPC_URL
         sync: false
       - key: SP1_PROVER


### PR DESCRIPTION
With Ginger: https://x.com/CelestiaOrg/status/1849465927357829519, block times are now 6s. Double the block interval accordingly on Mocha testnets.