### PR TITLE
fix(docs): table formatting in docs

### DIFF
--- a/book/quick-start.md
+++ b/book/quick-start.md
@@ -17,11 +17,11 @@ This guide will walk you through deploying the SP1 Blobstream contract and runni
 
 2. Add the genesis parameters to `/contracts/.env` mirroring `contracts/.env.example`.
 
-    | Parameter | Description |
-    |-----------|-------------|
-    | GENESIS_HEIGHT | The block height of the genesis block for the Tendermint chain |
-    | GENESIS_HEADER | The header of the genesis block for the Tendermint chain |
-    | SP1_BLOBSTREAM_PROGRAM_VKEY | The verification key for the SP1 Blobstream program |
+| Parameter                     | Description                                                    |
+| ----------------------------- | -------------------------------------------------------------- |
+| `GENESIS_HEIGHT`              | The block height of the genesis block for the Tendermint chain |
+| `GENESIS_HEADER`              | The header of the genesis block for the Tendermint chain       |
+| `SP1_BLOBSTREAM_PROGRAM_VKEY` | The verification key for the SP1 Blobstream program            |
 
 3. Deploy the `SP1Blobstream` contract with genesis parameters: `GENESIS_HEIGHT`, `GENESIS_HEADER`, and `SP1_BLOBSTREAM_PROGRAM_VKEY`.
 


### PR DESCRIPTION
## Description

Was going through the docs and found some formatting issues. This PR fixes it.

### Before:
<img width="821" alt="Screenshot 2025-01-24 at 1 55 47 PM" src="https://github.com/user-attachments/assets/a532b34d-9c85-450d-bcc8-4deccdec7b30" />



### After:
<img width="836" alt="Screenshot 2025-01-24 at 1 57 03 PM" src="https://github.com/user-attachments/assets/d51e5da6-64e6-4b3e-82de-007b734549ca" />
