### PR TITLE
feat(operator): simplify header fetching, timeout logic

### DIFF
--- a/script/bin/operator.rs
+++ b/script/bin/operator.rs
@@ -348,27 +348,37 @@ where
         loop {
             let request_interval_mins = get_loop_interval_mins();
 
-            tokio::select! {
-                _ = tokio::time::sleep(tokio::time::Duration::from_secs(60 * LOOP_TIMEOUT_MINS)) => {
-                    tracing::error!("Operator took longer than {} minutes to run.", LOOP_TIMEOUT_MINS);
-                    continue;
-                }
-                res = this.clone().run_operator_iteration().instrument(tracing::span!(tracing::Level::INFO, "operator")) => {
-                    if let Err(e) = res {
-                        tracing::error!("Error running operator: {:?}", e);
-
-                        // If there's an error, sleep for only 10 seconds. This will avoid
-                        // transient RPC downtime while ensuring that the operator recovers quickly.
-                        tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
-                        continue;
-                    }
-
+            // Use timeout instead of select for cleaner timeout handling
+            match tokio::time::timeout(
+                tokio::time::Duration::from_secs(60 * LOOP_TIMEOUT_MINS),
+                this.clone()
+                    .run_operator_iteration()
+                    .instrument(tracing::span!(tracing::Level::INFO, "operator")),
+            )
+            .await
+            {
+                Ok(Ok(())) => {
                     tracing::info!("Operator ran successfully.");
+                    // Sleep for the request interval
+                    tokio::time::sleep(tokio::time::Duration::from_secs(
+                        60 * request_interval_mins,
+                    ))
+                    .await;
+                }
+                Ok(Err(e)) => {
+                    tracing::error!("Error running operator: {:?}", e);
+                    // If there's an error, sleep for only 10 seconds
+                    tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+                }
+                Err(_) => {
+                    tracing::error!(
+                        "Operator took longer than {} minutes to run.",
+                        LOOP_TIMEOUT_MINS
+                    );
+                    // Sleep for a short time before retrying
+                    tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
                 }
             }
-
-            // Sleep for the request interval.
-            tokio::time::sleep(tokio::time::Duration::from_secs(60 * request_interval_mins)).await;
         }
     }
 }

--- a/script/bin/operator.rs
+++ b/script/bin/operator.rs
@@ -358,7 +358,7 @@ where
             .await
             {
                 Ok(Ok(())) => {
-                    tracing::info!("Operator ran successfully.");
+                    tracing::info!("Successfully ran operator iteration.");
                     // Sleep for the request interval
                     tokio::time::sleep(tokio::time::Duration::from_secs(
                         60 * request_interval_mins,
@@ -366,13 +366,13 @@ where
                     .await;
                 }
                 Ok(Err(e)) => {
-                    tracing::error!("Error running operator: {:?}", e);
+                    tracing::error!("Error running operator iteration: {:?}", e);
                     // If there's an error, sleep for only 10 seconds
                     tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
                 }
                 Err(_) => {
                     tracing::error!(
-                        "Operator took longer than {} minutes to run.",
+                        "Operator iteration took longer than {} minutes to run.",
                         LOOP_TIMEOUT_MINS
                     );
                     // Sleep for a short time before retrying

--- a/script/bin/operator.rs
+++ b/script/bin/operator.rs
@@ -53,7 +53,7 @@ const PROOF_TIMEOUT_SECONDS: u64 = 60 * 30;
 const NUM_RELAY_RETRIES: u32 = 3;
 
 /// The timeout for the operator to run.
-const LOOP_TIMEOUT_MINS: u64 = 20;
+const LOOP_TIMEOUT_MINS: u64 = PROOF_TIMEOUT_SECONDS * 2;
 
 /// The number of confirmations to wait for.
 const NUM_CONFIRMATIONS: u64 = 3;

--- a/script/src/util.rs
+++ b/script/src/util.rs
@@ -1,6 +1,6 @@
 use alloy::primitives::B256;
 use anyhow::Context;
-use futures::stream::FuturesOrdered;
+use futures::stream::iter;
 use futures::StreamExt;
 use sp1_blobstream_primitives::types::ProofInputs;
 use std::collections::HashMap;
@@ -13,10 +13,7 @@ use tendermint_light_client_verifier::types::{LightBlock, ValidatorSet};
 mod retry;
 pub use retry::{Retry, RetryFuture};
 
-use crate::tendermint::{
-    TendermintRPCClient, DEFAULT_FAILURES_ALLOWED, DEFAULT_TENDERMINT_RPC_CONCURRENCY,
-    DEFAULT_TENDERMINT_RPC_SLEEP_MS,
-};
+use crate::tendermint::{TendermintRPCClient, DEFAULT_TENDERMINT_RPC_CONCURRENCY};
 
 pub async fn fetch_input_for_blobstream_proof(
     client: &TendermintRPCClient,
@@ -124,72 +121,20 @@ pub async fn get_headers_in_range(
     start_height: u64,
     end_height: u64,
 ) -> anyhow::Result<Vec<Header>> {
-    let mut headers = Vec::with_capacity(((end_height - start_height) + 1) as usize);
+    let mut batch_headers = iter(start_height..end_height + 1)
+        .map(|height| async move {
+            get_block(client, height)
+                .await
+                .expect("Failed to fetch block")
+                .header
+        })
+        .buffer_unordered(DEFAULT_TENDERMINT_RPC_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
 
-    let mut failures: u32 = 0;
-    let mut next_batch_start = start_height;
+    batch_headers.sort_by_key(|header| header.height.value());
 
-    while next_batch_start <= end_height {
-        if failures == DEFAULT_FAILURES_ALLOWED {
-            return Err(anyhow::anyhow!(
-                "Got too many failures attempting to fetch block headers."
-            ));
-        }
-
-        // Top of the range is non-inclusive so max out at `end_height + 1`.
-        let batch_end = std::cmp::min(
-            next_batch_start + DEFAULT_TENDERMINT_RPC_CONCURRENCY as u64,
-            end_height + 1,
-        );
-
-        tracing::info!(
-            "Fetching headers from {} to {}",
-            next_batch_start,
-            batch_end - 1
-        );
-
-        // Chunk the range into batches of DEFAULT_TENDERMINT_RPC_CONCURRENCY.
-        let batch_headers: Vec<anyhow::Result<Header>> = (next_batch_start..batch_end)
-            .map(|height| async move { Ok(get_block(client, height).await?.header) })
-            .collect::<FuturesOrdered<_>>()
-            .collect::<Vec<_>>()
-            .await;
-
-        // Check if there are any errors.
-        let first_err = batch_headers.iter().position(|h| h.is_err());
-
-        if let Some(err) = first_err {
-            // If there is at least one valid result, then it doesn't count as a failure.
-            if err == 0 {
-                failures += 1;
-            }
-
-            tracing::debug!(
-                "Got errors fetching headers, successful header count: {}",
-                err
-            );
-
-            // Bump the start of the next batch by the number of successful headers in this batch.
-            next_batch_start += err as u64;
-
-            // Extend the headers with the headers that were not err.
-            headers.extend(batch_headers.into_iter().take(err).map(Result::unwrap));
-        } else {
-            // There are no errors, so reset the failure count to 0.
-            failures = 0;
-
-            // The next start should be the (not included) end of this batch.
-            next_batch_start = batch_end;
-
-            // Extend the headers with all of the headers in this batch.
-            headers.extend(batch_headers.into_iter().map(Result::unwrap));
-        }
-
-        // Sleep for 1.25 seconds to avoid rate limiting.
-        tokio::time::sleep(DEFAULT_TENDERMINT_RPC_SLEEP_MS * 2_u32.pow(failures)).await;
-    }
-
-    Ok(headers)
+    Ok(batch_headers)
 }
 
 /// Retrieves the latest block height from the Tendermint node.


### PR DESCRIPTION
## Overview
- Fix the timeout logic for the operator iteration to cancel the iteration on the event of a timeout.
- Fetch headers with `futures::stream::iter`.