### PR TITLE
fix: fix start trusted set

### DIFF
--- a/script/src/util.rs
+++ b/script/src/util.rs
@@ -302,6 +302,10 @@ pub fn is_valid_skip(
         {
             // Confirm that the validator has signed on target_block.
             for sig in target_block_commit.signatures.iter() {
+                if !sig.is_commit() {
+                    continue;
+                }
+
                 if let Some(validator_address) = sig.validator_address() {
                     if validator_address == target_block_validator.address {
                         // Add the shared voting power to the validator


### PR DESCRIPTION
## 1. Aligns the skip with the verifier’s actual trusted set.

In Tendermint light-client semantics the block you trust at height h carries forward the validator set for height h+1. When verifier evaluates the next header, it compares the commit against that next_validators set.

If the skip samples validators from height h instead of h+1, it can approve a transition that the verifier will reject, because the verifier never considers the height h set.

See the light client verifier code [here](https://github.com/cometbft/tendermint-rs/blob/d8c361ec5597e3f9a005d7211eec9c74eb9b04df/light-client-verifier/src/verifier.rs#L245).

## 2. Filter non-commit votes.

A commit’s voting power is defined only by signatures with `BlockIdFlag::Commit`. `BlockIdFlagAbsent` and `BlockIdFlagNil` votes don’t contribute. If the skip counts every signature including nil or absent, the tallied power can appear to hit 2/3 even though fewer than 2/3 of validators actually signed the block which will cause the verifier to later rejects it with `NotEnoughTrust` error and panic.

## 3. Check threshold for trusted validators

The original loop didn't compare the threshold against the trusted validator set's voting power.

The function still returned true as long as enough of the target set happened to be in the old validator set which causes the verifier to later rejects it with `NotEnoughTrust` error and panic.