### PR TITLE
chore: pin rust toolchain to 1.91.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.91.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
## Summary
- Add `rust-toolchain.toml` pinning to Rust 1.91.0
- Required by SP1 v6.1.0 dependencies (`sp1-sdk`, `sp1-prover-types`, etc.)
- Render's default rustc is 1.87.0; without this file, `sp1-blobstream-mocha` and `sp1-blobstream-mainnet` builds fail. RUST_VERSION env var on Render is not honored for Rust services.

## Test plan
- [x] CI passes (build with pinned toolchain)
- [ ] Render `sp1-blobstream-mocha` redeploys cleanly post-merge